### PR TITLE
(PS-88): fixing errors from previous sprints and adding QOL changes

### DIFF
--- a/point-system/.idea/misc.xml
+++ b/point-system/.idea/misc.xml
@@ -8,5 +8,5 @@
       </list>
     </option>
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_X" default="true" project-jdk-name="openjdk-22" project-jdk-type="JavaSDK" />
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_22" default="true" project-jdk-name="openjdk-22" project-jdk-type="JavaSDK" />
 </project>

--- a/point-system/src/main/java/pointsystem/config/SecurityConfig.java
+++ b/point-system/src/main/java/pointsystem/config/SecurityConfig.java
@@ -5,6 +5,8 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
+import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
@@ -19,6 +21,7 @@ import java.util.List;
 
 @Configuration
 @RequiredArgsConstructor
+@EnableMethodSecurity(prePostEnabled = true) // Replaces @EnableGlobalMethodSecurity
 public class SecurityConfig {
 
     private final JwtAuthenticationFilter jwtAuthenticationFilter;
@@ -36,8 +39,8 @@ public class SecurityConfig {
                                 "/swagger-ui.html",
                                 "/webjars/**",
                                 "/v3/api-docs.yaml"
-                        ).permitAll() // Allow public access to auth endpoints
-                        .anyRequest().authenticated() // Require authentication for all other endpoints
+                        ).permitAll()
+                        .anyRequest().authenticated()
                 )
                 .sessionManagement(session -> session
                         .sessionCreationPolicy(SessionCreationPolicy.STATELESS) // Use stateless sessions

--- a/point-system/src/main/java/pointsystem/controller/UserController.java
+++ b/point-system/src/main/java/pointsystem/controller/UserController.java
@@ -3,6 +3,7 @@ package pointsystem.controller;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 import pointsystem.dto.user.UserDto;
 import pointsystem.service.UserService;
@@ -13,6 +14,7 @@ import java.util.Map;
 @RestController
 @RequestMapping("/api/users")
 @RequiredArgsConstructor
+@PreAuthorize("hasRole('ADMIN')")
 public class UserController {
 
     private final UserService userService;

--- a/point-system/src/main/java/pointsystem/converter/UserConverter.java
+++ b/point-system/src/main/java/pointsystem/converter/UserConverter.java
@@ -30,7 +30,9 @@ public class UserConverter {
         if (entity == null) {
             return null;
         }
-        return modelMapper.map(entity, UserDto.class);
+        UserDto dto = modelMapper.map(entity, UserDto.class);
+        dto.setPassword(null);
+        return dto;
     }
 
     public UserEntity updateEntity(UserEntity entity, UserDto dto) {

--- a/point-system/src/main/java/pointsystem/service/AuthenticationService.java
+++ b/point-system/src/main/java/pointsystem/service/AuthenticationService.java
@@ -26,6 +26,7 @@ public class AuthenticationService {
         UserEntity userEntity = userConverter.toEntity(request);
 
         userEntity.setPassword(passwordEncoder.encode(userEntity.getPassword()));
+        userEntity.setEmail(request.getEmail().toLowerCase());
         if (!userEntity.isEmailvalidador()) {
             throw new IllegalArgumentException("E-mail e/ou senha incorretos. Tente novamente.");
         }
@@ -38,16 +39,12 @@ public class AuthenticationService {
 
     public AuthenticationResponseDto authenticate(AuthenticationRequestDto request) throws BadRequestException {
         try {
+            request.setEmail(request.getEmail().toLowerCase());
             authenticationManager.authenticate(
                     new UsernamePasswordAuthenticationToken(request.getEmail(), request.getPassword())
             );
         } catch (Exception e) {
-            boolean userExists = userRepository.findByEmail(request.getEmail()).isPresent();
-            if (userExists) {
-                throw new BadRequestException("E-mail e/ou senha incorretos. Tente novamente.");
-            } else {
-                throw new BadRequestException("E-mail e/ou senha incorretos. Tente novamente.");
-            }
+            throw new BadRequestException("E-mail e/ou senha incorretos. Tente novamente.");
         }
 
         UserEntity userEntity = userRepository.findByEmail(request.getEmail())

--- a/point-system/src/main/java/pointsystem/service/AuthenticationService.java
+++ b/point-system/src/main/java/pointsystem/service/AuthenticationService.java
@@ -28,7 +28,7 @@ public class AuthenticationService {
         userEntity.setPassword(passwordEncoder.encode(userEntity.getPassword()));
         userEntity.setEmail(request.getEmail().toLowerCase());
         if (!userEntity.isEmailvalidador()) {
-            throw new IllegalArgumentException("E-mail e/ou senha incorretos. Tente novamente.");
+            throw new IllegalArgumentException("O e-mail deve ser do domínio '@altave'");
         }
 
         UserEntity userEntitySaved = userRepository.save(userEntity);

--- a/point-system/src/main/java/pointsystem/service/UserService.java
+++ b/point-system/src/main/java/pointsystem/service/UserService.java
@@ -36,6 +36,7 @@ public class UserService {
         if (!user.isEmailvalidador()) {
             throw new IllegalArgumentException("O e-mail deve ser do domínio '@altave'");
         }
+        user.setEmail(userDto.getEmail().toLowerCase());
 
         UserEntity userSaved = userRepository.save(user);
         return userSaved.getUserId();
@@ -57,6 +58,7 @@ public class UserService {
             UserEntity user = userEntity.get();
             UserEntity updatedUserEntity = userConverter.updateEntity(user, userDto);
             updatedUserEntity.setPassword(passwordEncoder.encode(user.getPassword()));
+            updatedUserEntity.setEmail(userDto.getEmail().toLowerCase());
             userRepository.save(updatedUserEntity);
         }
     }

--- a/point-system/src/main/java/pointsystem/service/UserService.java
+++ b/point-system/src/main/java/pointsystem/service/UserService.java
@@ -2,6 +2,7 @@ package pointsystem.service;
 
 import jakarta.transaction.Transactional;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
 import pointsystem.converter.UserConverter;


### PR DESCRIPTION
- [x] Removed the password return when fetching user data, now set to null before returning;
- [x] User CRUD operations now only go trough if the given JWT token is classified as ADMIN;
- [x] Added to lowercase function to e-mail on login and registration endpoints, now steamducks@altave == SteamDucks@altave;
- [x] Added back incorrect domain error message, removed in a different task.